### PR TITLE
Minor Readme corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Speed=0
 i2c_line_RS=0x01
 i2c_line_RW=0x02
 i2c_line_EN=0x04
-i2c_line_BL=0x80
+i2c_line_BL=0x08
 i2c_line_D4=0x10
 i2c_line_D5=0x20
 i2c_line_D6=0x40
@@ -39,7 +39,7 @@ Backlight=yes
 BacklightInvert=yes
 ```
 
-The Backlight Invert is used if a 0 turns the backlight on, and 1 turns it off, i.e. npn
+The Backlight Invert is used if a 0 turns the backlight on, and 1 turns it off, i.e. PNP
  transistor
 
 See discussion here:


### PR DESCRIPTION
I think you mean that backlight is on the fourth lowest bit (0x8).

PNP transistors are active-low (conducts on negative voltage on base compared to emitter).
